### PR TITLE
fix(stop): use deallocation when stopping a machine

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -60,5 +60,7 @@ func BuildRoot() *cobra.Command {
 	rootCmd.AddCommand(NewStartCmd())
 	rootCmd.AddCommand(NewStatusCmd())
 	rootCmd.AddCommand(NewStopCmd())
+	rootCmd.AddCommand(NewStopRemoteCmd())
+	rootCmd.AddCommand(NewTokenCmd())
 	return rootCmd
 }

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -44,5 +44,5 @@ func (cmd *StopCmd) Run(
 	machine *provider.Machine,
 	logs log.Logger,
 ) error {
-	return nil
+	return azure.Stop(ctx, providerAzure)
 }

--- a/cmd/stop_remote.go
+++ b/cmd/stop_remote.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"context"
+
+	"github.com/loft-sh/devpod-provider-azure/pkg/azure"
+
+	"github.com/loft-sh/devpod/pkg/log"
+	"github.com/loft-sh/devpod/pkg/provider"
+	"github.com/spf13/cobra"
+)
+
+// StopRemoteCmd holds the cmd flags
+type StopRemoteCmd struct{}
+
+// NewStopRemoteCmd defines a command
+func NewStopRemoteCmd() *cobra.Command {
+	cmd := &StopRemoteCmd{}
+	stopRemoteCmd := &cobra.Command{
+		Use:   "stop-remote",
+		Short: "StopRemote an instance",
+		RunE: func(_ *cobra.Command, args []string) error {
+			azureProvider, err := azure.NewProvider(log.Default)
+			if err != nil {
+				return err
+			}
+
+			return cmd.Run(
+				context.Background(),
+				azureProvider,
+				provider.FromEnvironment(),
+				log.Default,
+			)
+		},
+	}
+
+	return stopRemoteCmd
+}
+
+// Run runs the command logic
+func (cmd *StopRemoteCmd) Run(
+	ctx context.Context,
+	providerAzure *azure.AzureProvider,
+	machine *provider.Machine,
+	logs log.Logger,
+) error {
+	return azure.StopRemote(ctx, providerAzure)
+}

--- a/cmd/token.go
+++ b/cmd/token.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"context"
+
+	"github.com/loft-sh/devpod-provider-azure/pkg/azure"
+	"github.com/loft-sh/devpod/pkg/log"
+	"github.com/loft-sh/devpod/pkg/provider"
+	"github.com/spf13/cobra"
+)
+
+// TokenCmd holds the cmd flags
+type TokenCmd struct{}
+
+// NewTokenCmd defines a command
+func NewTokenCmd() *cobra.Command {
+	cmd := &TokenCmd{}
+	tokenCmd := &cobra.Command{
+		Use:   "token",
+		Short: "Token an instance",
+		RunE: func(_ *cobra.Command, args []string) error {
+			azureProvider, err := azure.NewProvider(log.Default)
+			if err != nil {
+				return err
+			}
+
+			return cmd.Run(
+				context.Background(),
+				azureProvider,
+				provider.FromEnvironment(),
+				log.Default,
+			)
+		},
+	}
+
+	return tokenCmd
+}
+
+// Run runs the command logic
+func (cmd *TokenCmd) Run(
+	ctx context.Context,
+	providerAzure *azure.AzureProvider,
+	machine *provider.Machine,
+	logs log.Logger,
+) error {
+	return azure.Token(ctx, providerAzure)
+}

--- a/hack/provider/provider.yaml
+++ b/hack/provider/provider.yaml
@@ -151,14 +151,31 @@ options:
   AGENT_PATH:
     description: The path where to inject the DevPod agent to.
     default: /var/lib/toolbox/devpod
+  AZURE_PROVIDER_TOKEN:
+    local: true
+    hidden: true
+    cache: 5m
+    description: "The Azure Cloud auth token to use"
+    command: |-
+      ${AZURE_PROVIDER} token
 agent:
   path: ${AGENT_PATH}
   inactivityTimeout: ${INACTIVITY_TIMEOUT}
   injectGitCredentials: ${INJECT_GIT_CREDENTIALS}
   injectDockerCredentials: ${INJECT_DOCKER_CREDENTIALS}
+  binaries:
+    AZURE_PROVIDER:
+      - os: linux
+        arch: amd64
+        path: https://github.com/loft-sh/devpod-provider-azure/releases/download/##VERSION##/devpod-provider-azure-linux-amd64
+        checksum: ##CHECKSUM_LINUX_AMD64##
+      - os: linux
+        arch: arm64
+        path: https://github.com/loft-sh/devpod-provider-azure/releases/download/##VERSION##/devpod-provider-azure-linux-arm64
+        checksum: ##CHECKSUM_LINUX_ARM64##
   exec:
     shutdown: |-
-      shutdown -h now
+      ${AZURE_PROVIDER} stop-remote || shutdown
 binaries:
   AZURE_PROVIDER:
     - os: linux

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -45,17 +45,17 @@ func FromEnv(init bool) (*Options, error) {
 
 	var err error
 
-	retOptions.ResourceGroup, err = fromEnvOrError(AZURE_RESOURCE_GROUP)
+	retOptions.ResourceGroup, err = FromEnvOrError(AZURE_RESOURCE_GROUP)
 	if err != nil {
 		return nil, err
 	}
 
-	retOptions.MachineType, err = fromEnvOrError(AZURE_INSTANCE_SIZE)
+	retOptions.MachineType, err = FromEnvOrError(AZURE_INSTANCE_SIZE)
 	if err != nil {
 		return nil, err
 	}
 
-	image, err := fromEnvOrError(AZURE_IMAGE)
+	image, err := FromEnvOrError(AZURE_IMAGE)
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +69,7 @@ func FromEnv(init bool) (*Options, error) {
 	retOptions.DiskImage.SKU = imageSplit[2]
 	retOptions.DiskImage.Version = imageSplit[3]
 
-	diskSizeGB, err := fromEnvOrError(AZURE_DISK_SIZE)
+	diskSizeGB, err := FromEnvOrError(AZURE_DISK_SIZE)
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +79,7 @@ func FromEnv(init bool) (*Options, error) {
 		return nil, err
 	}
 
-	retOptions.DiskType, err = fromEnvOrError(AZURE_DISK_TYPE)
+	retOptions.DiskType, err = FromEnvOrError(AZURE_DISK_TYPE)
 	if err != nil {
 		return nil, err
 	}
@@ -87,12 +87,12 @@ func FromEnv(init bool) (*Options, error) {
 	// Optional
 	retOptions.CustomData = os.Getenv(AZURE_CUSTOM_DATA)
 
-	retOptions.Zone, err = fromEnvOrError(AZURE_REGION)
+	retOptions.Zone, err = FromEnvOrError(AZURE_REGION)
 	if err != nil {
 		return nil, err
 	}
 
-	retOptions.SubscriptionID, err = fromEnvOrError(AZURE_SUBSCRIPTION_ID)
+	retOptions.SubscriptionID, err = FromEnvOrError(AZURE_SUBSCRIPTION_ID)
 	if err != nil {
 		return nil, err
 	}
@@ -102,14 +102,14 @@ func FromEnv(init bool) (*Options, error) {
 		return retOptions, nil
 	}
 
-	retOptions.MachineID, err = fromEnvOrError("MACHINE_ID")
+	retOptions.MachineID, err = FromEnvOrError("MACHINE_ID")
 	if err != nil {
 		return nil, err
 	}
 	// prefix with devpod-
 	retOptions.MachineID = "devpod-" + retOptions.MachineID
 
-	retOptions.MachineFolder, err = fromEnvOrError("MACHINE_FOLDER")
+	retOptions.MachineFolder, err = FromEnvOrError("MACHINE_FOLDER")
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +117,7 @@ func FromEnv(init bool) (*Options, error) {
 	return retOptions, nil
 }
 
-func fromEnvOrError(name string) (string, error) {
+func FromEnvOrError(name string) (string, error) {
 	val := os.Getenv(name)
 	if val == "" {
 		return "", fmt.Errorf(


### PR DESCRIPTION
This PR implements 2 changes:

- `provider stop` now uses deallocation, to contain costs

Fix #14 
Resolves POD-623

- introduce `provider token` command to forward a bearer token to the machine, so that the remote agent can use the new provider's `provider stop-remote` command, to deallocate the machine after $timeout. It will fallback to regular shutdown in case of failure.

Fix #15 
Resolves POD-626